### PR TITLE
v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- \BristolSU\ControlDB\Contracts\Repositories\User::paginate()
+- \BristolSU\ControlDB\Contracts\Repositories\User::count()
+- \BristolSU\ControlDB\Contracts\Repositories\DataUser::getAllWhere()
+- \BristolSU\ControlDB\Contracts\Repositories\Group::paginate()
+- \BristolSU\ControlDB\Contracts\Repositories\Group::count()
+- \BristolSU\ControlDB\Contracts\Repositories\DataGroup::getAllWhere()
+- \BristolSU\ControlDB\Contracts\Repositories\Role::paginate()
+- \BristolSU\ControlDB\Contracts\Repositories\Role::count()
+- \BristolSU\ControlDB\Contracts\Repositories\DataRole::getAllWhere()
+- \BristolSU\ControlDB\Contracts\Repositories\Position::paginate()
+- \BristolSU\ControlDB\Contracts\Repositories\Position::count()
+- \BristolSU\ControlDB\Contracts\Repositories\DataPosition::getAllWhere()
+- \BristolSU\ControlDB\Http\Controllers\Controller::paginate to slice and paginate through a list of items
+- \BristolSU\ControlDB\Http\Controllers\Controller::paginationResponse to paginate through a sliced list of items
+- Add timings of formatters to logs when exporting
+
+### Changed
+- \BristolSU\ControlDB\Http\Controllers\Group\GroupController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Group\GroupGroupTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Group\GroupRoleController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Group\GroupUserController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\GroupTag\GroupTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\GroupTag\GroupTagGroupController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\GroupTagCategory\GroupTagCategoryController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\GroupTagCategory\GroupTagCategoryGroupTagController::index returns a LengthAwarePaginator
+
+- \BristolSU\ControlDB\Http\Controllers\Position\PositionController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Position\PositionPositionTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Position\PositionRoleController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\PositionTag\PositionTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\PositionTag\PositionTagPositionController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\PositionTagCategory\PositionTagCategoryController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\PositionTagCategory\PositionTagCategoryPositionTagController::index returns a LengthAwarePaginator
+
+- \BristolSU\ControlDB\Http\Controllers\Role\RoleController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Role\RoleRoleTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\Role\RoleUserController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\RoleTag\RoleTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\RoleTag\RoleTagRoleController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\RoleTagCategory\RoleTagCategoryController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\RoleTagCategory\RoleTagCategoryRoleTagController::index returns a LengthAwarePaginator
+
+- \BristolSU\ControlDB\Http\Controllers\User\UserController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\User\UserGroupController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\User\UserRoleController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\User\UserUserTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\UserTag\UserTagController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\UserTag\UserTagUserController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\UserTagCategory\UserTagCategoryController::index returns a LengthAwarePaginator
+- \BristolSU\ControlDB\Http\Controllers\UserTagCategory\UserTagCategoryUserTagController::index returns a LengthAwarePaginator
+
 ## [1.3.0] - (08/04/2020)
 
 ### Added

--- a/config/control.php
+++ b/config/control.php
@@ -5,7 +5,7 @@ return [
     'api_middleware' => [
         'api'
     ],
-    
+    'log-formatters' => env('LOG_CONTROL_FORMATTERS', false),
     'export' => [
 
         /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::namespace('Group')->group(function() {
+    Route::get('group/search', 'GroupController@search');
     Route::apiResource('group', 'GroupController')->parameter('group', 'control_group');
     Route::apiResource('group.tag', 'GroupGroupTagController')->only(['index', 'update', 'destroy'])->parameters(['group' => 'control_group', 'tag' => 'control_group_tag']);
     Route::apiResource('group.user', 'GroupUserController')->only(['index', 'update', 'destroy'])->parameters(['group' => 'control_group', 'user' => 'control_user']);
@@ -21,6 +22,7 @@ Route::namespace('Group')->group(function() {
 });
 
 Route::namespace('User')->group(function() {
+    Route::get('user/search', 'UserController@search');
     Route::apiResource('user', 'UserController')->parameter('user', 'control_user');
     Route::apiResource('user.tag', 'UserUserTagController')->only(['index', 'update', 'destroy'])->parameters(['user' => 'control_user', 'tag' => 'control_user_tag']);
     Route::apiResource('user.role', 'UserRoleController')->only(['index', 'update', 'destroy'])->parameters(['user' => 'control_user', 'role' => 'control_role']);
@@ -36,6 +38,7 @@ Route::namespace('Role')->group(function() {
 });
 
 Route::namespace('Position')->group(function() {
+    Route::get('position/search', 'PositionController@search');
     Route::apiResource('position', 'PositionController')->parameter('position', 'control_position');
     Route::apiResource('position.tag', 'PositionPositionTagController')->only(['index', 'update', 'destroy'])->parameters(['position' => 'control_position', 'tag' => 'control_position_tag']);
     Route::apiResource('position.role', 'PositionRoleController')->only(['index'])->parameters(['position' => 'control_position']);

--- a/src/Cache/Role.php
+++ b/src/Cache/Role.php
@@ -84,4 +84,27 @@ class Role implements RoleRepositoryContract
     {
         return $this->roleRepository->allThroughPosition($position);
     }
+
+    /**
+     * Paginate through all the roles
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|RoleModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection
+    {
+        return $this->roleRepository->paginate($page, $perPage);
+    }
+
+    /**
+     * Get the number of roles
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return $this->roleRepository->count();
+    }
 }

--- a/src/Contracts/Repositories/DataGroup.php
+++ b/src/Contracts/Repositories/DataGroup.php
@@ -2,6 +2,8 @@
 
 namespace BristolSU\ControlDB\Contracts\Repositories;
 
+use Illuminate\Support\Collection;
+
 /**
  * Handle attributes of a group
  */
@@ -24,6 +26,13 @@ interface DataGroup
      */
     public function getWhere($attributes = []): \BristolSU\ControlDB\Contracts\Models\DataGroup;
 
+    /**
+     * Get all data groups where the given attributes match, including additional attributes.
+     *
+     * @param array $attributes
+     * @return Collection|\BristolSU\ControlDB\Contracts\Models\DataGroup[]
+     */
+    public function getAllWhere($attributes = []): Collection;
     /**
      * Create a group with the given attributes
      * 

--- a/src/Contracts/Repositories/DataPosition.php
+++ b/src/Contracts/Repositories/DataPosition.php
@@ -2,6 +2,8 @@
 
 namespace BristolSU\ControlDB\Contracts\Repositories;
 
+use Illuminate\Support\Collection;
+
 /**
  * Handle attributes of a position
  */
@@ -32,4 +34,12 @@ interface DataPosition
      * @return \BristolSU\ControlDB\Contracts\Models\DataPosition
      */
     public function create(?string $name = null, ?string $description = null): \BristolSU\ControlDB\Contracts\Models\DataPosition;
+
+    /**
+     * Get all data positions where the given attributes match, including additional attributes.
+     *
+     * @param array $attributes
+     * @return Collection|\BristolSU\ControlDB\Contracts\Models\DataPosition[]
+     */
+    public function getAllWhere($attributes = []): Collection;
 }

--- a/src/Contracts/Repositories/DataRole.php
+++ b/src/Contracts/Repositories/DataRole.php
@@ -2,6 +2,8 @@
 
 namespace BristolSU\ControlDB\Contracts\Repositories;
 
+use Illuminate\Support\Collection;
+
 /**
  * Handle attributes of a role
  */
@@ -23,7 +25,15 @@ interface DataRole
      * @return \BristolSU\ControlDB\Contracts\Models\DataRole
      */
     public function getWhere($attributes = []): \BristolSU\ControlDB\Contracts\Models\DataRole;
-
+    
+    /**
+     * Get all data roles where the given attributes match, including additional attributes.
+     *
+     * @param array $attributes
+     * @return Collection|\BristolSU\ControlDB\Contracts\Models\DataRole[]
+     */
+    public function getAllWhere($attributes = []): Collection;
+    
     /**
      * Create a data position with the given attributes
      * 

--- a/src/Contracts/Repositories/DataUser.php
+++ b/src/Contracts/Repositories/DataUser.php
@@ -4,6 +4,8 @@
 namespace BristolSU\ControlDB\Contracts\Repositories;
 
 
+use Illuminate\Support\Collection;
+
 /**
  * Handle attributes of a user
  */
@@ -26,6 +28,14 @@ interface DataUser
      */
     public function getWhere($attributes = []): \BristolSU\ControlDB\Contracts\Models\DataUser;
 
+    /**
+     * Get all data users where the given attributes match, including additional attributes.
+     *
+     * @param array $attributes
+     * @return Collection|\BristolSU\ControlDB\Contracts\Models\DataUser[]
+     */
+    public function getAllWhere($attributes = []): Collection;
+    
     /**
      * Create a data user with the given attributes
      * 

--- a/src/Contracts/Repositories/Group.php
+++ b/src/Contracts/Repositories/Group.php
@@ -49,4 +49,20 @@ interface Group
      */
     public function delete(int $id): void;
 
+    /**
+     * Paginate through all the groups
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|GroupModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection;
+
+    /**
+     * Get the number of groups
+     *
+     * @return int
+     */
+    public function count(): int;
 }

--- a/src/Contracts/Repositories/Position.php
+++ b/src/Contracts/Repositories/Position.php
@@ -48,4 +48,20 @@ interface Position
      */
     public function delete(int $id): void;
 
+    /**
+     * Paginate through all the positions
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|PositionModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection;
+
+    /**
+     * Get the number of positions
+     *
+     * @return int
+     */
+    public function count(): int;
 }

--- a/src/Contracts/Repositories/Role.php
+++ b/src/Contracts/Repositories/Role.php
@@ -67,5 +67,22 @@ interface Role
      * @return Collection|RoleModel[]
      */
     public function allThroughPosition(\BristolSU\ControlDB\Contracts\Models\Position $position): Collection;
+
+    /**
+     * Paginate through all the roles
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|RoleModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection;
+
+    /**
+     * Get the number of roles
+     *
+     * @return int
+     */
+    public function count(): int;
     
 }

--- a/src/Contracts/Repositories/User.php
+++ b/src/Contracts/Repositories/User.php
@@ -47,4 +47,22 @@ interface User
      * @param int $id
      */
     public function delete(int $id): void;
+
+    /**
+     * Paginate through all the users
+     * 
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     * 
+     * @return Collection|UserModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection;
+
+    /**
+     * Get the number of users
+     * 
+     * @return int
+     */
+    public function count(): int;
+    
 }

--- a/src/Export/Handler/Handler.php
+++ b/src/Export/Handler/Handler.php
@@ -5,6 +5,7 @@ namespace BristolSU\ControlDB\Export\Handler;
 use BristolSU\ControlDB\Export\FormattedItem;
 use BristolSU\ControlDB\Export\Formatter\Formatter;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 
 abstract class Handler
 {
@@ -40,7 +41,10 @@ abstract class Handler
         }
         $formattedItems = $this->prepareItems($items);
         foreach($this->getFormatters() as $formatter) {
+            $time=-hrtime(true);
             $formattedItems = $formatter->format($formattedItems);
+            $time+=hrtime(true);
+            $this->logTime(class_basename($formatter), $time / 1e+9);
         }
         $this->save($formattedItems);
     }
@@ -76,5 +80,12 @@ abstract class Handler
             return $this->config[$key];
         }
         return $default;
+    }
+
+    private function logTime(string $formatter, float $time)
+    {
+        if(config('control.log-formatters')) {
+            Log::info(sprintf('Formatter [%s] took %.2f s to run', $formatter, $time));
+        }
     }
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -5,9 +5,34 @@ namespace BristolSU\ControlDB\Http\Controllers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    public function paginate($items)
+    {
+        $perPage = request()->input('per_page', 10);
+        $page = request()->input('page', 1);
+        
+        $slicedItems = collect($items)->forPage($page, $perPage)->values();
+        
+        return $this->paginationResponse($slicedItems, count($items));
+    }
+
+    public function paginationResponse($items, $count)
+    {
+        $perPage = request()->input('per_page', 10);
+        $page = request()->input('page', 1);
+
+        return (new LengthAwarePaginator(
+            $items,
+            $count,
+            $perPage,
+            $page,
+            ['path' => url(request()->path())]
+        ))->appends('per_page', $perPage);
+    }
 }

--- a/src/Http/Controllers/Group/GroupGroupTagController.php
+++ b/src/Http/Controllers/Group/GroupGroupTagController.php
@@ -5,6 +5,8 @@ namespace BristolSU\ControlDB\Http\Controllers\Group;
 use BristolSU\ControlDB\Http\Controllers\Controller;
 use BristolSU\ControlDB\Contracts\Models\Group;
 use BristolSU\ControlDB\Contracts\Models\Tags\GroupTag;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 /**
  * Handles a group tags link to a group
@@ -14,13 +16,13 @@ class GroupGroupTagController extends Controller
 
     /**
      * Get all group tags through a group
-     * 
+     *
      * @param Group $group
-     * @return \Illuminate\Support\Collection
+     * @return LengthAwarePaginator
      */
     public function index(Group $group)
     {
-        return $group->tags();
+        return $this->paginate($group->tags());
     }
 
     /**

--- a/src/Http/Controllers/Group/GroupRoleController.php
+++ b/src/Http/Controllers/Group/GroupRoleController.php
@@ -15,11 +15,11 @@ class GroupRoleController extends Controller
      * Get all roles belonging to this group
      * 
      * @param Group $group
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(Group $group)
     {
-        return $group->roles();
+        return $this->paginate($group->roles());
     }
 
 }

--- a/src/Http/Controllers/Group/GroupUserController.php
+++ b/src/Http/Controllers/Group/GroupUserController.php
@@ -16,11 +16,11 @@ class GroupUserController extends Controller
      * Get all users from a group
      * 
      * @param Group $group
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(Group $group)
     {
-        return $group->members();
+        return $this->paginate($group->members());
     }
 
     /**

--- a/src/Http/Controllers/GroupTag/GroupTagController.php
+++ b/src/Http/Controllers/GroupTag/GroupTagController.php
@@ -18,11 +18,11 @@ class GroupTagController extends Controller
      * Get all group tags
      * 
      * @param GroupTagRepository $groupTagRepository
-     * @return GroupTag[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(GroupTagRepository $groupTagRepository)
     {
-        return $groupTagRepository->all();
+        return $this->paginate($groupTagRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/GroupTag/GroupTagGroupController.php
+++ b/src/Http/Controllers/GroupTag/GroupTagGroupController.php
@@ -15,11 +15,11 @@ class GroupTagGroupController extends Controller
      * Get all groups with the given tag
      * 
      * @param GroupTag $groupTag
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(GroupTag $groupTag)
     {
-        return $groupTag->groups();
+        return $this->paginate($groupTag->groups());
     }
 
     /**

--- a/src/Http/Controllers/GroupTagCategory/GroupTagCategoryController.php
+++ b/src/Http/Controllers/GroupTagCategory/GroupTagCategoryController.php
@@ -16,11 +16,11 @@ class GroupTagCategoryController extends Controller
     /**
      * Get all group tag categories
      * @param GroupTagCategoryRepository $groupTagCategoryRepository
-     * @return GroupTagCategory[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(GroupTagCategoryRepository $groupTagCategoryRepository)
     {
-        return $groupTagCategoryRepository->all();
+        return $this->paginate($groupTagCategoryRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/GroupTagCategory/GroupTagCategoryGroupTagController.php
+++ b/src/Http/Controllers/GroupTagCategory/GroupTagCategoryGroupTagController.php
@@ -15,11 +15,11 @@ class GroupTagCategoryGroupTagController extends Controller
      * Get all tags belonging to the group tag category
      * 
      * @param GroupTagCategory $groupTagCategory
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(GroupTagCategory $groupTagCategory)
     {
-        return $groupTagCategory->tags();
+        return $this->paginate($groupTagCategory->tags());
     }
 
 }

--- a/src/Http/Controllers/Position/PositionPositionTagController.php
+++ b/src/Http/Controllers/Position/PositionPositionTagController.php
@@ -16,11 +16,11 @@ class PositionPositionTagController extends Controller
      * Get all tags belonging to the current position
      * 
      * @param Position $position
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(Position $position)
     {
-        return $position->tags();
+        return $this->paginate($position->tags());
     }
 
     /**

--- a/src/Http/Controllers/Position/PositionRoleController.php
+++ b/src/Http/Controllers/Position/PositionRoleController.php
@@ -15,11 +15,11 @@ class PositionRoleController extends Controller
      * Get all roles which have the given position
      * 
      * @param Position $position
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(Position $position)
     {
-        return $position->roles();
+        return $this->paginate($position->roles());
     }
 
 }

--- a/src/Http/Controllers/PositionTag/PositionTagController.php
+++ b/src/Http/Controllers/PositionTag/PositionTagController.php
@@ -18,11 +18,11 @@ class PositionTagController extends Controller
      * Get all position tags
      * 
      * @param PositionTagRepository $positionTagRepository
-     * @return PositionTag[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(PositionTagRepository $positionTagRepository)
     {
-        return $positionTagRepository->all();
+        return $this->paginate($positionTagRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/PositionTag/PositionTagPositionController.php
+++ b/src/Http/Controllers/PositionTag/PositionTagPositionController.php
@@ -15,11 +15,11 @@ class PositionTagPositionController extends Controller
      * Get all positions with the given tag
      * 
      * @param PositionTag $positionTag
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(PositionTag $positionTag)
     {
-        return $positionTag->positions();
+        return $this->paginate($positionTag->positions());
     }
 
     /**

--- a/src/Http/Controllers/PositionTagCategory/PositionTagCategoryController.php
+++ b/src/Http/Controllers/PositionTagCategory/PositionTagCategoryController.php
@@ -16,11 +16,11 @@ class PositionTagCategoryController extends Controller
     /**
      * Get all position tag categories
      * @param PositionTagCategoryRepository $positionTagCategoryRepository
-     * @return PositionTagCategory[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(PositionTagCategoryRepository $positionTagCategoryRepository)
     {
-        return $positionTagCategoryRepository->all();
+        return $this->paginate($positionTagCategoryRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/PositionTagCategory/PositionTagCategoryPositionTagController.php
+++ b/src/Http/Controllers/PositionTagCategory/PositionTagCategoryPositionTagController.php
@@ -15,11 +15,11 @@ class PositionTagCategoryPositionTagController extends Controller
      * Get all tags belonging to the position tag category
      * 
      * @param PositionTagCategory $positionTagCategory
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(PositionTagCategory $positionTagCategory)
     {
-        return $positionTagCategory->tags();
+        return $this->paginate($positionTagCategory->tags());
     }
 
 }

--- a/src/Http/Controllers/Role/RoleController.php
+++ b/src/Http/Controllers/Role/RoleController.php
@@ -8,6 +8,9 @@ use BristolSU\ControlDB\Http\Requests\Api\Role\UpdateRoleRequest;
 use BristolSU\ControlDB\Contracts\Repositories\DataRole as DataRoleRepository;
 use BristolSU\ControlDB\Contracts\Repositories\Role as RoleRepository;
 use BristolSU\ControlDB\Contracts\Models\Role;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 
 /**
  * Handle roles
@@ -17,13 +20,20 @@ class RoleController extends Controller
 
     /**
      * Get all roles
-     * 
+     *
+     * @param Request $request
      * @param RoleRepository $roleRepository
-     * @return Role[]|\Illuminate\Support\Collection
+     * @return LengthAwarePaginator
      */
-    public function index(RoleRepository $roleRepository)
+    public function index(Request $request, RoleRepository $roleRepository)
     {
-        return $roleRepository->all();
+        $perPage = $request->input('per_page', 10);
+        $page = $request->input('page', 1);
+
+        return $this->paginationResponse(
+            $roleRepository->paginate($page, $perPage),
+            $roleRepository->count()
+        );
     }
 
     /**

--- a/src/Http/Controllers/Role/RoleRoleTagController.php
+++ b/src/Http/Controllers/Role/RoleRoleTagController.php
@@ -16,11 +16,11 @@ class RoleRoleTagController extends Controller
      * Get all tags belonging to the current role
      *
      * @param Role $role
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(Role $role)
     {
-        return $role->tags();
+        return $this->paginate($role->tags());
     }
 
     /**

--- a/src/Http/Controllers/Role/RoleUserController.php
+++ b/src/Http/Controllers/Role/RoleUserController.php
@@ -18,11 +18,11 @@ class RoleUserController extends Controller
      * Get all users belonging to a group
      * 
      * @param Role $role
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(Role $role)
     {
-        return $role->users();
+        return $this->paginate($role->users());
     }
 
     /**

--- a/src/Http/Controllers/RoleTag/RoleTagController.php
+++ b/src/Http/Controllers/RoleTag/RoleTagController.php
@@ -18,11 +18,11 @@ class RoleTagController extends Controller
      * Get all role tags
      * 
      * @param RoleTagRepository $roleTagRepository
-     * @return RoleTag[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(RoleTagRepository $roleTagRepository)
     {
-        return $roleTagRepository->all();
+        return $this->paginate($roleTagRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/RoleTag/RoleTagRoleController.php
+++ b/src/Http/Controllers/RoleTag/RoleTagRoleController.php
@@ -15,11 +15,11 @@ class RoleTagRoleController extends Controller
      * Get all roles with the given tag
      * 
      * @param RoleTag $roleTag
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(RoleTag $roleTag)
     {
-        return $roleTag->roles();
+        return $this->paginate($roleTag->roles());
     }
 
     /**

--- a/src/Http/Controllers/RoleTagCategory/RoleTagCategoryController.php
+++ b/src/Http/Controllers/RoleTagCategory/RoleTagCategoryController.php
@@ -16,11 +16,11 @@ class RoleTagCategoryController extends Controller
     /**
      * Get all role tag categories
      * @param RoleTagCategoryRepository $roleTagCategoryRepository
-     * @return RoleTagCategory[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(RoleTagCategoryRepository $roleTagCategoryRepository)
     {
-        return $roleTagCategoryRepository->all();
+        return $this->paginate($roleTagCategoryRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/RoleTagCategory/RoleTagCategoryRoleTagController.php
+++ b/src/Http/Controllers/RoleTagCategory/RoleTagCategoryRoleTagController.php
@@ -15,11 +15,11 @@ class RoleTagCategoryRoleTagController extends Controller
      * Get all tags belonging to the role tag category
      * 
      * @param RoleTagCategory $roleTagCategory
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(RoleTagCategory $roleTagCategory)
     {
-        return $roleTagCategory->tags();
+        return $this->paginate($roleTagCategory->tags());
     }
 
 }

--- a/src/Http/Controllers/User/UserGroupController.php
+++ b/src/Http/Controllers/User/UserGroupController.php
@@ -18,11 +18,11 @@ class UserGroupController extends Controller
      * Get all groups that belong to a user
      * 
      * @param User $user
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(User $user)
     {
-        return $user->groups();
+        return $this->paginate($user->groups());
     }
 
     /**

--- a/src/Http/Controllers/User/UserRoleController.php
+++ b/src/Http/Controllers/User/UserRoleController.php
@@ -18,11 +18,11 @@ class UserRoleController extends Controller
      * Get all roles that belong to a user
      *
      * @param User $user
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(User $user)
     {
-        return $user->roles();
+        return $this->paginate($user->roles());
     }
 
     /**

--- a/src/Http/Controllers/User/UserUserTagController.php
+++ b/src/Http/Controllers/User/UserUserTagController.php
@@ -16,11 +16,12 @@ class UserUserTagController extends Controller
      * Get all tags belonging to the current user
      *
      * @param User $user
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(User $user)
     {
-        return $user->tags();
+        return $this->paginate($user->tags());
+        
     }
 
     /**

--- a/src/Http/Controllers/UserTag/UserTagController.php
+++ b/src/Http/Controllers/UserTag/UserTagController.php
@@ -18,11 +18,11 @@ class UserTagController extends Controller
      * Get all user tags
      * 
      * @param UserTagRepository $userTagRepository
-     * @return UserTag[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(UserTagRepository $userTagRepository)
     {
-        return $userTagRepository->all();
+        return $this->paginate($userTagRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/UserTag/UserTagUserController.php
+++ b/src/Http/Controllers/UserTag/UserTagUserController.php
@@ -15,11 +15,11 @@ class UserTagUserController extends Controller
      * Get all users with the given tag
      * 
      * @param UserTag $userTag
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(UserTag $userTag)
     {
-        return $userTag->users();
+        return $this->paginate($userTag->users());
     }
 
     /**

--- a/src/Http/Controllers/UserTagCategory/UserTagCategoryController.php
+++ b/src/Http/Controllers/UserTagCategory/UserTagCategoryController.php
@@ -16,11 +16,11 @@ class UserTagCategoryController extends Controller
     /**
      * Get all user tag categories
      * @param UserTagCategoryRepository $userTagCategoryRepository
-     * @return UserTagCategory[]|\Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(UserTagCategoryRepository $userTagCategoryRepository)
     {
-        return $userTagCategoryRepository->all();
+        return $this->paginate($userTagCategoryRepository->all());
     }
 
     /**

--- a/src/Http/Controllers/UserTagCategory/UserTagCategoryUserTagController.php
+++ b/src/Http/Controllers/UserTagCategory/UserTagCategoryUserTagController.php
@@ -15,11 +15,11 @@ class UserTagCategoryUserTagController extends Controller
      * Get all tags belonging to the user tag category
      * 
      * @param UserTagCategory $userTagCategory
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function index(UserTagCategory $userTagCategory)
     {
-        return $userTagCategory->tags();
+        return $this->paginate($userTagCategory->tags());
     }
 
 }

--- a/src/Repositories/DataGroup.php
+++ b/src/Repositories/DataGroup.php
@@ -3,6 +3,7 @@
 namespace BristolSU\ControlDB\Repositories;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
 
 class DataGroup implements \BristolSU\ControlDB\Contracts\Repositories\DataGroup
 {
@@ -26,25 +27,10 @@ class DataGroup implements \BristolSU\ControlDB\Contracts\Repositories\DataGroup
      */
     public function getWhere($attributes = []): \BristolSU\ControlDB\Contracts\Models\DataGroup
     {
-        $baseAttributes = $attributes;
-        $additionalAttributes = [];
-        foreach(\BristolSU\ControlDB\Models\DataGroup::getAdditionalAttributes() as $property) {
-            if(array_key_exists($property, $baseAttributes)) {
-                $additionalAttributes[$property] = $baseAttributes[$property];
-                unset($baseAttributes[$property]);
-            }
-        }
-        $users = \BristolSU\ControlDB\Models\DataGroup::where($baseAttributes)->get()->filter(function(\BristolSU\ControlDB\Models\DataGroup $dataGroup) use ($additionalAttributes) {
-            foreach($additionalAttributes as $additionalAttribute => $value) {
-                if($dataGroup->getAdditionalAttribute($additionalAttribute) !== $value) {
-                    return false;
-                }
-            }
-            return true;
-        })->values();
+        $groups = $this->getAllWhere($attributes);
         
-        if($users->count() > 0) {
-            return $users->first();
+        if($groups->count() > 0) {
+            return $groups->first();
         }
         throw (new ModelNotFoundException())->setModel(DataGroup::class);
     }
@@ -62,5 +48,36 @@ class DataGroup implements \BristolSU\ControlDB\Contracts\Repositories\DataGroup
             'name' => $name,
             'email' => $email,
         ]);
+    }
+
+    /**
+     * Get all data groups where the given attributes match, including additional attributes.
+     *
+     * @param array $attributes
+     * @return Collection
+     */
+    public function getAllWhere($attributes = []): Collection
+    {
+        $baseAttributes = $attributes;
+        $additionalAttributes = [];
+        foreach (\BristolSU\ControlDB\Models\DataGroup::getAdditionalAttributes() as $property) {
+            if (array_key_exists($property, $baseAttributes)) {
+                $additionalAttributes[$property] = $baseAttributes[$property];
+                unset($baseAttributes[$property]);
+            }
+        }
+        return \BristolSU\ControlDB\Models\DataGroup::where(function($query) use ($baseAttributes) {
+            foreach($baseAttributes as $key => $value) {
+                $query = $query->orWhere($key, 'LIKE', '%' . $value . '%');
+            }
+            return $query;
+        })->get()->filter(function (\BristolSU\ControlDB\Models\DataGroup $dataGroup) use ($additionalAttributes) {
+            foreach ($additionalAttributes as $additionalAttribute => $value) {
+                if ($dataGroup->getAdditionalAttribute($additionalAttribute) !== $value) {
+                    return false;
+                }
+            }
+            return true;
+        })->values();
     }
 }

--- a/src/Repositories/Group.php
+++ b/src/Repositories/Group.php
@@ -66,4 +66,27 @@ class Group implements GroupContract
         return \BristolSU\ControlDB\Models\Group::where('data_provider_id', $dataProviderId)->firstOrFail();
     }
 
+    /**
+     * Paginate through all the groups
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|GroupModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection
+    {
+        return \BristolSU\ControlDB\Models\Group::paginate($perPage, ['*'], 'page', $page)->getCollection();
+    }
+
+    /**
+     * Get the number of groups
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return \BristolSU\ControlDB\Models\Group::count();
+    }
+
 }

--- a/src/Repositories/Position.php
+++ b/src/Repositories/Position.php
@@ -66,4 +66,27 @@ class Position implements PositionContract
         return \BristolSU\ControlDB\Models\Position::where('data_provider_id', $dataProviderId)->firstOrFail();
     }
 
+    /**
+     * Paginate through all the positions
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|PositionModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection
+    {
+        return \BristolSU\ControlDB\Models\Position::paginate($perPage, ['*'], 'page', $page)->getCollection();
+    }
+
+    /**
+     * Get the number of positions
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return \BristolSU\ControlDB\Models\Position::count();
+    }
+    
 }

--- a/src/Repositories/Role.php
+++ b/src/Repositories/Role.php
@@ -94,4 +94,27 @@ class Role implements RoleContract
     {
         return \BristolSU\ControlDB\Models\Role::where('position_id', $position->id())->get();
     }
+
+    /**
+     * Paginate through all the roles
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|RoleModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection
+    {
+        return \BristolSU\ControlDB\Models\Role::paginate($perPage, ['*'], 'page', $page)->getCollection();
+    }
+
+    /**
+     * Get the number of roles
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return \BristolSU\ControlDB\Models\Role::count();
+    }
 }

--- a/src/Repositories/User.php
+++ b/src/Repositories/User.php
@@ -66,4 +66,28 @@ class User implements UserContract
         return \BristolSU\ControlDB\Models\User::where('data_provider_id', $dataProviderId)->firstOrFail();
     }
 
+    /**
+     * Paginate through all the users
+     *
+     * @param int $page The page number to return
+     * @param int $perPage The number of results to return per page
+     *
+     * @return Collection|UserModel[]
+     */
+    public function paginate(int $page, int $perPage): Collection
+    {
+        return \BristolSU\ControlDB\Models\User::paginate($perPage, ['*'], 'page', $page)->getCollection();
+    }
+
+    /**
+     * Get the number of users
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return \BristolSU\ControlDB\Models\User::count();
+    }
+
+
 }

--- a/tests/Integration/Http/Controllers/Group/GroupGroupTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/Group/GroupGroupTagControllerTest.php
@@ -26,8 +26,9 @@ class GroupGroupTagControllerTest extends TestCase
         $response = $this->getJson($this->apiUrl . '/group/' . $group->id() . '/tag');
         $response->assertStatus(200);
         
-        $response->assertJsonCount(5);
-        foreach($response->json() as $groupTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        $response->assertPaginatedResponse();
+        foreach($response->paginatedJson() as $groupTagThroughApi) {
             $this->assertArrayHasKey('id', $groupTagThroughApi);
             $this->assertEquals($groupTags->shift()->id(), $groupTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/Group/GroupRoleControllerTest.php
+++ b/tests/Integration/Http/Controllers/Group/GroupRoleControllerTest.php
@@ -17,9 +17,9 @@ class GroupRoleControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/group/' . $group->id() . '/role');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleThroughApi) {
             $this->assertArrayHasKey('id', $roleThroughApi);
             $this->assertEquals($roles->shift()->id(), $roleThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/Group/GroupUserControllerTest.php
+++ b/tests/Integration/Http/Controllers/Group/GroupUserControllerTest.php
@@ -25,9 +25,10 @@ class GroupUserControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/group/' . $group->id() . '/user');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $userThroughApi) {
+        $response->assertPaginatedResponse();
+
+        $response->assertPaginatedJsonCount(5, 'data');
+        foreach($response->paginatedJson() as $userThroughApi) {
             $this->assertArrayHasKey('id', $userThroughApi);
             $this->assertEquals($users->shift()->id(), $userThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/GroupTag/GroupTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/GroupTag/GroupTagControllerTest.php
@@ -15,8 +15,9 @@ class GroupTagControllerTest extends TestCase
         $response = $this->getJson($this->apiUrl . '/group-tag');
         $response->assertStatus(200);
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $groupTagThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $groupTagThroughApi) {
             $this->assertArrayHasKey('id', $groupTagThroughApi);
             $this->assertEquals($groupTags->shift()->id(), $groupTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/GroupTag/GroupTagGroupControllerTest.php
+++ b/tests/Integration/Http/Controllers/GroupTag/GroupTagGroupControllerTest.php
@@ -25,9 +25,10 @@ class GroupTagGroupControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/group-tag/' . $groupTag->id() . '/group');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach ($response->json() as $groupThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach ($response->paginatedJson() as $groupThroughApi) {
             $this->assertArrayHasKey('id', $groupThroughApi);
             $this->assertEquals($groups->shift()->id(), $groupThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/GroupTagCategory/GroupTagCategoryControllerTest.php
+++ b/tests/Integration/Http/Controllers/GroupTagCategory/GroupTagCategoryControllerTest.php
@@ -13,9 +13,9 @@ class GroupTagCategoryControllerTest extends TestCase
         $groupTagCategories = factory(GroupTagCategory::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/group-tag-category');
         $response->assertStatus(200);
-
-        $response->assertJsonCount(5);
-        foreach($response->json() as $groupTagCategoryThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $groupTagCategoryThroughApi) {
             $this->assertArrayHasKey('id', $groupTagCategoryThroughApi);
             $this->assertEquals($groupTagCategories->shift()->id(), $groupTagCategoryThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/GroupTagCategory/GroupTagCategoryGroupTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/GroupTagCategory/GroupTagCategoryGroupTagControllerTest.php
@@ -16,9 +16,10 @@ class GroupTagCategoryGroupTagControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/group-tag-category/' . $groupTagCategory->id() . '/group-tag');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $groupTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $groupTagThroughApi) {
             $this->assertArrayHasKey('id', $groupTagThroughApi);
             $this->assertEquals($groupTags->shift()->id(), $groupTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/Position/PositionControllerTest.php
+++ b/tests/Integration/Http/Controllers/Position/PositionControllerTest.php
@@ -8,17 +8,32 @@ use BristolSU\Tests\ControlDB\TestCase;
 
 class PositionControllerTest extends TestCase
 {
-
     /** @test */
-    public function it_returns_all_positions(){
+    public function it_returns_all_positions()
+    {
         $positions = factory(Position::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/position');
         $response->assertStatus(200);
-
-        $response->assertJsonCount(5);
-        foreach($response->json() as $positionThroughApi) {
+        
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach ($response->paginatedJson() as $positionThroughApi) {
             $this->assertArrayHasKey('id', $positionThroughApi);
             $this->assertEquals($positions->shift()->id(), $positionThroughApi['id']);
+        }
+    }
+
+    /** @test */
+    public function it_limits_positions_by_the_pagination_options(){
+        $positions = factory(Position::class, 50)->create();
+        $response = $this->getJson($this->apiUrl . '/position?page=2&per_page=15');
+        $response->assertStatus(200);
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(15);
+        $paginatedPositions = $positions->slice(15, 15)->values();
+        foreach ($response->paginatedJson() as $positionThroughApi) {
+            $this->assertArrayHasKey('id', $positionThroughApi);
+            $this->assertEquals($paginatedPositions->shift()->id(), $positionThroughApi['id']);
         }
     }
 

--- a/tests/Integration/Http/Controllers/Position/PositionPositionTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/Position/PositionPositionTagControllerTest.php
@@ -25,9 +25,10 @@ class PositionPositionTagControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/position/' . $position->id() . '/tag');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $positionTagThroughApi) {
+        $response->assertPaginatedResponse();
+
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $positionTagThroughApi) {
             $this->assertArrayHasKey('id', $positionTagThroughApi);
             $this->assertEquals($positionTags->shift()->id(), $positionTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/Position/PositionRoleControllerTest.php
+++ b/tests/Integration/Http/Controllers/Position/PositionRoleControllerTest.php
@@ -17,9 +17,9 @@ class PositionRoleControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/position/' . $position->id() . '/role');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleThroughApi) {
             $this->assertArrayHasKey('id', $roleThroughApi);
             $this->assertEquals($roles->shift()->id(), $roleThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/PositionTag/PositionTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/PositionTag/PositionTagControllerTest.php
@@ -14,9 +14,10 @@ class PositionTagControllerTest extends TestCase
         $positionTags = factory(PositionTag::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/position-tag');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $positionTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $positionTagThroughApi) {
             $this->assertArrayHasKey('id', $positionTagThroughApi);
             $this->assertEquals($positionTags->shift()->id(), $positionTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/PositionTag/PositionTagPositionControllerTest.php
+++ b/tests/Integration/Http/Controllers/PositionTag/PositionTagPositionControllerTest.php
@@ -25,9 +25,10 @@ class PositionTagPositionControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/position-tag/' . $positionTag->id() . '/position');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach ($response->json() as $positionThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach ($response->paginatedJson() as $positionThroughApi) {
             $this->assertArrayHasKey('id', $positionThroughApi);
             $this->assertEquals($positions->shift()->id(), $positionThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/PositionTagCategory/PositionTagCategoryControllerTest.php
+++ b/tests/Integration/Http/Controllers/PositionTagCategory/PositionTagCategoryControllerTest.php
@@ -14,8 +14,9 @@ class PositionTagCategoryControllerTest extends TestCase
         $response = $this->getJson($this->apiUrl . '/position-tag-category');
         $response->assertStatus(200);
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $positionTagCategoryThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $positionTagCategoryThroughApi) {
             $this->assertArrayHasKey('id', $positionTagCategoryThroughApi);
             $this->assertEquals($positionTagCategories->shift()->id(), $positionTagCategoryThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/PositionTagCategory/PositionTagCategoryPositionTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/PositionTagCategory/PositionTagCategoryPositionTagControllerTest.php
@@ -16,9 +16,10 @@ class PositionTagCategoryPositionTagControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/position-tag-category/' . $positionTagCategory->id() . '/position-tag');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $positionTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $positionTagThroughApi) {
             $this->assertArrayHasKey('id', $positionTagThroughApi);
             $this->assertEquals($positionTags->shift()->id(), $positionTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/Role/RoleControllerTest.php
+++ b/tests/Integration/Http/Controllers/Role/RoleControllerTest.php
@@ -12,18 +12,34 @@ class RoleControllerTest extends TestCase
 {
 
     /** @test */
-    public function it_returns_all_roles(){
+    public function it_returns_all_roles()
+    {
         $roles = factory(Role::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/role');
         $response->assertStatus(200);
-
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleThroughApi) {
+        
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach ($response->paginatedJson() as $roleThroughApi) {
             $this->assertArrayHasKey('id', $roleThroughApi);
             $this->assertEquals($roles->shift()->id(), $roleThroughApi['id']);
         }
     }
 
+    /** @test */
+    public function it_limits_roles_by_the_pagination_options(){
+        $roles = factory(Role::class, 50)->create();
+        $response = $this->getJson($this->apiUrl . '/role?page=2&per_page=15');
+        $response->assertStatus(200);
+
+        $response->assertJsonCount(15, 'data');
+        $paginatedRoles = $roles->slice(15, 15)->values();
+        foreach ($response->json()['data'] as $roleThroughApi) {
+            $this->assertArrayHasKey('id', $roleThroughApi);
+            $this->assertEquals($paginatedRoles->shift()->id(), $roleThroughApi['id']);
+        }
+    }
+    
     /** @test */
     public function it_returns_a_single_role(){
         $dataRole = factory(DataRole::class)->create();

--- a/tests/Integration/Http/Controllers/Role/RoleRoleTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/Role/RoleRoleTagControllerTest.php
@@ -25,9 +25,9 @@ class RoleRoleTagControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/role/' . $role->id() . '/tag');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleTagThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleTagThroughApi) {
             $this->assertArrayHasKey('id', $roleTagThroughApi);
             $this->assertEquals($roleTags->shift()->id(), $roleTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/Role/RoleUserControllerTest.php
+++ b/tests/Integration/Http/Controllers/Role/RoleUserControllerTest.php
@@ -25,9 +25,10 @@ class RoleUserControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/role/' . $role->id() . '/user');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $userThroughApi) {
+        $response->assertPaginatedResponse();
+
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $userThroughApi) {
             $this->assertArrayHasKey('id', $userThroughApi);
             $this->assertEquals($users->shift()->id(), $userThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/RoleTag/RoleTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/RoleTag/RoleTagControllerTest.php
@@ -14,9 +14,9 @@ class RoleTagControllerTest extends TestCase
         $roleTags = factory(RoleTag::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/role-tag');
         $response->assertStatus(200);
-
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleTagThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleTagThroughApi) {
             $this->assertArrayHasKey('id', $roleTagThroughApi);
             $this->assertEquals($roleTags->shift()->id(), $roleTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/RoleTag/RoleTagRoleControllerTest.php
+++ b/tests/Integration/Http/Controllers/RoleTag/RoleTagRoleControllerTest.php
@@ -25,9 +25,10 @@ class RoleTagRoleControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/role-tag/' . $roleTag->id() . '/role');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach ($response->json() as $roleThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach ($response->paginatedJson() as $roleThroughApi) {
             $this->assertArrayHasKey('id', $roleThroughApi);
             $this->assertEquals($roles->shift()->id(), $roleThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/RoleTag/RoleTagRoleTagCategoryControllerTest.php
+++ b/tests/Integration/Http/Controllers/RoleTag/RoleTagRoleTagCategoryControllerTest.php
@@ -15,7 +15,6 @@ class RoleTagRoleTagCategoryControllerTest extends TestCase
         $tag = factory(RoleTag::class)->create(['id' => 20, 'tag_category_id' => $tagCategory->id()]);
         
         $response = $this->getJson($this->apiUrl . '/role-tag/' . $tag->id() . '/role-tag-category');
-        
         $response->assertStatus(200);
         $response->assertJsonFragment(['id' => $tagCategory->id()]);
     }

--- a/tests/Integration/Http/Controllers/RoleTagCategory/RoleTagCategoryControllerTest.php
+++ b/tests/Integration/Http/Controllers/RoleTagCategory/RoleTagCategoryControllerTest.php
@@ -13,9 +13,9 @@ class RoleTagCategoryControllerTest extends TestCase
         $roleTagCategories = factory(RoleTagCategory::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/role-tag-category');
         $response->assertStatus(200);
-
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleTagCategoryThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleTagCategoryThroughApi) {
             $this->assertArrayHasKey('id', $roleTagCategoryThroughApi);
             $this->assertEquals($roleTagCategories->shift()->id(), $roleTagCategoryThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/RoleTagCategory/RoleTagCategoryRoleTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/RoleTagCategory/RoleTagCategoryRoleTagControllerTest.php
@@ -16,9 +16,10 @@ class RoleTagCategoryRoleTagControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/role-tag-category/' . $roleTagCategory->id() . '/role-tag');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleTagThroughApi) {
             $this->assertArrayHasKey('id', $roleTagThroughApi);
             $this->assertEquals($roleTags->shift()->id(), $roleTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/User/UserGroupControllerTest.php
+++ b/tests/Integration/Http/Controllers/User/UserGroupControllerTest.php
@@ -24,9 +24,10 @@ class UserGroupControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/user/' . $user->id() . '/group');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $groupThroughApi) {
+        $response->assertPaginatedResponse();
+
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $groupThroughApi) {
             $this->assertArrayHasKey('id', $groupThroughApi);
             $this->assertEquals($groups->shift()->id(), $groupThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/User/UserRoleControllerTest.php
+++ b/tests/Integration/Http/Controllers/User/UserRoleControllerTest.php
@@ -24,9 +24,10 @@ class UserRoleControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/user/' . $user->id() . '/role');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $roleThroughApi) {
+        $response->assertPaginatedResponse();
+
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $roleThroughApi) {
             $this->assertArrayHasKey('id', $roleThroughApi);
             $this->assertEquals($roles->shift()->id(), $roleThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/User/UserUserTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/User/UserUserTagControllerTest.php
@@ -25,9 +25,10 @@ class UserUserTagControllerTest extends TestCase
         
         $response = $this->getJson($this->apiUrl . '/user/' . $user->id() . '/tag');
         $response->assertStatus(200);
-        
-        $response->assertJsonCount(5);
-        foreach($response->json() as $userTagThroughApi) {
+        $response->assertPaginatedResponse();
+
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $userTagThroughApi) {
             $this->assertArrayHasKey('id', $userTagThroughApi);
             $this->assertEquals($userTags->shift()->id(), $userTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/UserTag/UserTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/UserTag/UserTagControllerTest.php
@@ -14,9 +14,10 @@ class UserTagControllerTest extends TestCase
         $userTags = factory(UserTag::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/user-tag');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $userTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $userTagThroughApi) {
             $this->assertArrayHasKey('id', $userTagThroughApi);
             $this->assertEquals($userTags->shift()->id(), $userTagThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/UserTag/UserTagUserControllerTest.php
+++ b/tests/Integration/Http/Controllers/UserTag/UserTagUserControllerTest.php
@@ -25,9 +25,10 @@ class UserTagUserControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/user-tag/' . $userTag->id() . '/user');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach ($response->json() as $userThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach ($response->paginatedJson() as $userThroughApi) {
             $this->assertArrayHasKey('id', $userThroughApi);
             $this->assertEquals($users->shift()->id(), $userThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/UserTagCategory/UserTagCategoryControllerTest.php
+++ b/tests/Integration/Http/Controllers/UserTagCategory/UserTagCategoryControllerTest.php
@@ -13,9 +13,9 @@ class UserTagCategoryControllerTest extends TestCase
         $userTagCategories = factory(UserTagCategory::class, 5)->create();
         $response = $this->getJson($this->apiUrl . '/user-tag-category');
         $response->assertStatus(200);
-
-        $response->assertJsonCount(5);
-        foreach($response->json() as $userTagCategoryThroughApi) {
+        $response->assertPaginatedResponse();
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $userTagCategoryThroughApi) {
             $this->assertArrayHasKey('id', $userTagCategoryThroughApi);
             $this->assertEquals($userTagCategories->shift()->id(), $userTagCategoryThroughApi['id']);
         }

--- a/tests/Integration/Http/Controllers/UserTagCategory/UserTagCategoryUserTagControllerTest.php
+++ b/tests/Integration/Http/Controllers/UserTagCategory/UserTagCategoryUserTagControllerTest.php
@@ -16,9 +16,10 @@ class UserTagCategoryUserTagControllerTest extends TestCase
 
         $response = $this->getJson($this->apiUrl . '/user-tag-category/' . $userTagCategory->id() . '/user-tag');
         $response->assertStatus(200);
+        $response->assertPaginatedResponse();
 
-        $response->assertJsonCount(5);
-        foreach($response->json() as $userTagThroughApi) {
+        $response->assertPaginatedJsonCount(5);
+        foreach($response->paginatedJson() as $userTagThroughApi) {
             $this->assertArrayHasKey('id', $userTagThroughApi);
             $this->assertEquals($userTags->shift()->id(), $userTagThroughApi['id']);
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace BristolSU\Tests\ControlDB;
 
 use BristolSU\ControlDB\ControlDBServiceProvider;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\TestResponse;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -18,6 +19,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
         $this->loadMigrationsFrom(realpath(__DIR__ . '/../database/migrations'));
         $this->withFactories(__DIR__ . '/../database/factories');
+        $this->setupPagination();
     }
 
     public function getEnvironmentSetUp($app)
@@ -43,5 +45,10 @@ abstract class TestCase extends BaseTestCase
         return [
             ControlDBServiceProvider::class,
         ];
+    }
+
+    private function setupPagination()
+    {
+        TestResponse::mixin(new TestResponseMixin());
     }
 }

--- a/tests/TestResponseMixin.php
+++ b/tests/TestResponseMixin.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BristolSU\Tests\ControlDB;
+
+use Illuminate\Foundation\Testing\TestResponse;
+use Illuminate\Foundation\Testing\Assert as PHPUnit;
+
+/**
+ * @mixin TestResponse
+ */
+class TestResponseMixin
+{
+
+    public function assertPaginatedResponse()
+    {
+        return function () {
+            $this->assertJsonStructure([
+                'current_page', 'data', 'first_page_url', 'from', 'last_page', 'last_page_url', 'next_page_url', 'path',
+                'per_page', 'prev_page_url', 'to', 'total'
+            ]);
+        };
+    }
+
+    public function assertPerPage()
+    {
+        return function ($perPage) {
+
+            $realPerPage = $this->json('per_page');
+            PHPUnit::assertNotNull($realPerPage, 'No per page attribute found');
+
+            PHPUnit::assertEquals($perPage, $realPerPage);
+        };
+    }
+
+    public function assertPageIs()
+    {
+        return function ($page) {
+
+            $realPage = $this->json('current_page');
+            PHPUnit::assertNotNull($realPage, 'No current page attribute found');
+
+            PHPUnit::assertEquals($page, $realPage);
+        };
+    }
+
+    public function assertTotalPages()
+    {
+        return function ($total) {
+
+            $totalPages = $this->json('last_page');
+            PHPUnit::assertNotNull($totalPages, 'No last page attribute found');
+
+            PHPUnit::assertEquals($total, $totalPages);
+        };
+    }
+
+    public function assertTotalRecords()
+    {
+        return function ($total) {
+
+            $totalRecords = $this->json('total');
+            PHPUnit::assertNotNull($totalRecords, 'No total attribute found');
+
+            PHPUnit::assertEquals($total, $totalRecords);
+        };
+    }
+
+    public function paginatedJson()
+    {
+        return function () {
+            return $this->json('data');
+        };
+    }
+
+    public function assertPaginatedJsonCount()
+    {
+        return function($expected) {
+            return $this->assertJsonCount($expected, 'data');
+        };
+    }
+
+}

--- a/tests/Unit/Repositories/DataGroupTest.php
+++ b/tests/Unit/Repositories/DataGroupTest.php
@@ -97,4 +97,19 @@ class DataGroupTest extends TestCase
         $this->assertTrue($dataGroup2->is($dbDataGroup2));
     }
 
+    /** @test */
+    public function getAllWhere_returns_all_model_matching_the_attributes(){
+        DataGroup::addProperty('additionalAttr');
+        $attributes = ['email' => 'email@email.com', 'additional_attributes' => json_encode(['additionalAttr' => 15])];
+
+        $dataGroups = factory(DataGroup::class, 2)->create($attributes);
+        factory(DataGroup::class, 4)->create(['additional_attributes' => json_encode(['additionalAttr' => 5])]);
+
+        $repository = new \BristolSU\ControlDB\Repositories\DataGroup();
+        $dbDataGroup = $repository->getAllWhere($attributes);
+
+        $this->assertEquals(2, $dbDataGroup->count());
+        $this->assertTrue($dataGroups[0]->is($dbDataGroup[0]));
+        $this->assertTrue($dataGroups[1]->is($dbDataGroup[1]));
+    }
 }

--- a/tests/Unit/Repositories/DataPositionTest.php
+++ b/tests/Unit/Repositories/DataPositionTest.php
@@ -97,4 +97,19 @@ class DataPositionTest extends TestCase
         $this->assertTrue($dataPosition2->is($dbDataPosition2));
     }
 
+    /** @test */
+    public function getAllWhere_returns_all_model_matching_the_attributes(){
+        DataPosition::addProperty('additionalAttr');
+        $attributes = ['name' => 'abc123', 'additional_attributes' => json_encode(['additionalAttr' => 15])];
+
+        $dataPositions = factory(DataPosition::class, 2)->create($attributes);
+        factory(DataPosition::class, 4)->create(['additional_attributes' => json_encode(['additionalAttr' => 5])]);
+
+        $repository = new \BristolSU\ControlDB\Repositories\DataPosition();
+        $dbDataPosition = $repository->getAllWhere($attributes);
+
+        $this->assertEquals(2, $dbDataPosition->count());
+        $this->assertTrue($dataPositions[0]->is($dbDataPosition[0]));
+        $this->assertTrue($dataPositions[1]->is($dbDataPosition[1]));
+    }
 }

--- a/tests/Unit/Repositories/DataRoleTest.php
+++ b/tests/Unit/Repositories/DataRoleTest.php
@@ -97,4 +97,20 @@ class DataRoleTest extends TestCase
         $this->assertTrue($dataRole2->is($dbDataRole2));
     }
 
+    /** @test */
+    public function getAllWhere_returns_all_model_matching_the_attributes(){
+        DataRole::addProperty('additionalAttr');
+        $attributes = ['email' => 'email@email.com', 'additional_attributes' => json_encode(['additionalAttr' => 15])];
+
+        $dataRoles = factory(DataRole::class, 2)->create($attributes);
+        factory(DataRole::class, 4)->create(['additional_attributes' => json_encode(['additionalAttr' => 5])]);
+
+        $repository = new \BristolSU\ControlDB\Repositories\DataRole();
+        $dbDataRole = $repository->getAllWhere($attributes);
+
+        $this->assertEquals(2, $dbDataRole->count());
+        $this->assertTrue($dataRoles[0]->is($dbDataRole[0]));
+        $this->assertTrue($dataRoles[1]->is($dbDataRole[1]));
+    }
+
 }

--- a/tests/Unit/Repositories/DataUserTest.php
+++ b/tests/Unit/Repositories/DataUserTest.php
@@ -28,6 +28,22 @@ class DataUserTest extends TestCase
         $repository = new \BristolSU\ControlDB\Repositories\DataUser();
         $repository->getById(1);
     }
+
+    /** @test */
+    public function getAllWhere_returns_all_model_matching_the_attributes(){
+        DataUser::addProperty('additionalAttr');
+        $attributes = ['email' => 'email@email.com', 'additional_attributes' => json_encode(['additionalAttr' => 15])];
+
+        $dataUsers = factory(DataUser::class, 2)->create($attributes);
+        factory(DataUser::class, 4)->create(['additional_attributes' => json_encode(['additionalAttr' => 5])]);
+
+        $repository = new \BristolSU\ControlDB\Repositories\DataUser();
+        $dbDataUser = $repository->getAllWhere($attributes);
+
+        $this->assertEquals(2, $dbDataUser->count());
+        $this->assertTrue($dataUsers[0]->is($dbDataUser[0]));
+        $this->assertTrue($dataUsers[1]->is($dbDataUser[1]));
+    }
     
     /** @test */
     public function getWhere_returns_the_first_model_matching_the_attributes(){

--- a/tests/Unit/Repositories/GroupTest.php
+++ b/tests/Unit/Repositories/GroupTest.php
@@ -96,4 +96,31 @@ class GroupTest extends TestCase
         $this->assertTrue($group->trashed());
     }
 
+    /** @test */
+    public function count_returns_the_number_of_groups(){
+        $groups = factory(Group::class, 18)->create();
+        $groupRepo = new \BristolSU\ControlDB\Repositories\Group();
+
+        $this->assertEquals(18, $groupRepo->count());
+    }
+
+    /** @test */
+    public function paginate_returns_the_number_of_groups_specified_for_the_given_page(){
+        $groups = factory(Group::class, 40)->create();
+        $groupRepo = new \BristolSU\ControlDB\Repositories\Group();
+
+        $paginatedGroups = $groupRepo->paginate(2, 10);
+        $this->assertEquals(10, $paginatedGroups->count());
+        $this->assertTrue($groups[10]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[11]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[12]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[13]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[14]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[15]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[16]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[17]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[18]->is($paginatedGroups->shift()));
+        $this->assertTrue($groups[19]->is($paginatedGroups->shift()));
+    }
+    
 }

--- a/tests/Unit/Repositories/PositionTest.php
+++ b/tests/Unit/Repositories/PositionTest.php
@@ -96,4 +96,31 @@ class PositionTest extends TestCase
         $this->assertTrue($position->trashed());
     }
 
+    /** @test */
+    public function count_returns_the_number_of_positions(){
+        $positions = factory(Position::class, 18)->create();
+        $positionRepo = new \BristolSU\ControlDB\Repositories\Position();
+
+        $this->assertEquals(18, $positionRepo->count());
+    }
+
+    /** @test */
+    public function paginate_returns_the_number_of_positions_specified_for_the_given_page(){
+        $positions = factory(Position::class, 40)->create();
+        $positionRepo = new \BristolSU\ControlDB\Repositories\Position();
+
+        $paginatedPositions = $positionRepo->paginate(2, 10);
+        $this->assertEquals(10, $paginatedPositions->count());
+        $this->assertTrue($positions[10]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[11]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[12]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[13]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[14]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[15]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[16]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[17]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[18]->is($paginatedPositions->shift()));
+        $this->assertTrue($positions[19]->is($paginatedPositions->shift()));
+    }
+
 }

--- a/tests/Unit/Repositories/RoleTest.php
+++ b/tests/Unit/Repositories/RoleTest.php
@@ -132,4 +132,31 @@ class RoleTest extends TestCase
         }
     }
 
+    /** @test */
+    public function count_returns_the_number_of_roles(){
+        $roles = factory(Role::class, 18)->create();
+        $roleRepo = new \BristolSU\ControlDB\Repositories\Role();
+
+        $this->assertEquals(18, $roleRepo->count());
+    }
+
+    /** @test */
+    public function paginate_returns_the_number_of_roles_specified_for_the_given_page(){
+        $roles = factory(Role::class, 40)->create();
+        $roleRepo = new \BristolSU\ControlDB\Repositories\Role();
+
+        $paginatedRoles = $roleRepo->paginate(2, 10);
+        $this->assertEquals(10, $paginatedRoles->count());
+        $this->assertTrue($roles[10]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[11]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[12]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[13]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[14]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[15]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[16]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[17]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[18]->is($paginatedRoles->shift()));
+        $this->assertTrue($roles[19]->is($paginatedRoles->shift()));
+    }
+
 }

--- a/tests/Unit/Repositories/UserTest.php
+++ b/tests/Unit/Repositories/UserTest.php
@@ -6,6 +6,7 @@ use BristolSU\ControlDB\Models\DataUser;
 use BristolSU\ControlDB\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use BristolSU\Tests\ControlDB\TestCase;
+use Illuminate\Support\Collection;
 
 class UserTest extends TestCase
 {
@@ -94,6 +95,33 @@ class UserTest extends TestCase
 
         $user->refresh();
         $this->assertTrue($user->trashed());
+    }
+    
+    /** @test */
+    public function count_returns_the_number_of_users(){
+        $users = factory(User::class, 18)->create();
+        $userRepo = new \BristolSU\ControlDB\Repositories\User();
+        
+        $this->assertEquals(18, $userRepo->count());
+    }
+    
+    /** @test */
+    public function paginate_returns_the_number_of_users_specified_for_the_given_page(){
+        $users = factory(User::class, 40)->create();
+        $userRepo = new \BristolSU\ControlDB\Repositories\User();
+
+        $paginatedUsers = $userRepo->paginate(2, 10);
+        $this->assertEquals(10, $paginatedUsers->count());
+        $this->assertTrue($users[10]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[11]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[12]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[13]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[14]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[15]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[16]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[17]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[18]->is($paginatedUsers->shift()));
+        $this->assertTrue($users[19]->is($paginatedUsers->shift()));
     }
 
 }


### PR DESCRIPTION
Breaking change updates to include pagination

- ### Added pagination to all API endpoints that return an array
- ### Added pagination to some repositories
- \BristolSU\ControlDB\Contracts\Repositories\User::paginate()
- \BristolSU\ControlDB\Contracts\Repositories\User::count()
- \BristolSU\ControlDB\Contracts\Repositories\DataUser::getAllWhere()
- \BristolSU\ControlDB\Contracts\Repositories\Group::paginate()
- \BristolSU\ControlDB\Contracts\Repositories\Group::count()
- \BristolSU\ControlDB\Contracts\Repositories\DataGroup::getAllWhere()
- \BristolSU\ControlDB\Contracts\Repositories\Role::paginate()
- \BristolSU\ControlDB\Contracts\Repositories\Role::count()
- \BristolSU\ControlDB\Contracts\Repositories\DataRole::getAllWhere()
- \BristolSU\ControlDB\Contracts\Repositories\Position::paginate()
- \BristolSU\ControlDB\Contracts\Repositories\Position::count()
- \BristolSU\ControlDB\Contracts\Repositories\DataPosition::getAllWhere()
- ### Added the ability to log timings for exports